### PR TITLE
Change includes and install routine to check for BuddyPress and openlab-theme

### DIFF
--- a/cbox-openlab-core.php
+++ b/cbox-openlab-core.php
@@ -25,22 +25,24 @@ function cboxol_init() {
 
 	require CBOXOL_PLUGIN_DIR . 'includes/functions.php';
 	require CBOXOL_PLUGIN_DIR . 'includes/member-types.php';
-	require CBOXOL_PLUGIN_DIR . 'includes/group-types.php';
-	require CBOXOL_PLUGIN_DIR . 'includes/group-sites.php';
+	require CBOXOL_PLUGIN_DIR . 'includes/group-categories.php';
+
+	if ( function_exists( 'buddypress' ) && bp_is_active( 'groups' ) ) {
+		if ( ! class_exists( 'Bp_Customizable_Group_Categories' ) ) {
+			require CBOXOL_PLUGIN_DIR . 'lib/bp-customizable-group-categories/bp-customizable-group-categories.php';
+			$bpcgc_plugin = new Bp_Customizable_Group_Categories();
+			$bpcgc_plugin->run();
+		}
+		require CBOXOL_PLUGIN_DIR . 'includes/group-types.php';
+		require CBOXOL_PLUGIN_DIR . 'includes/group-sites.php';
+	}
+
 	require CBOXOL_PLUGIN_DIR . 'includes/brand-settings.php';
 	require CBOXOL_PLUGIN_DIR . 'includes/academic-units.php';
 	require CBOXOL_PLUGIN_DIR . 'includes/related-links.php';
 	require CBOXOL_PLUGIN_DIR . 'includes/registration.php';
-	require CBOXOL_PLUGIN_DIR . 'includes/network-toolbar.php';
 	require CBOXOL_PLUGIN_DIR . 'includes/communication-settings.php';
 	require CBOXOL_PLUGIN_DIR . 'includes/profile-fields.php';
-
-	require CBOXOL_PLUGIN_DIR . 'includes/group-categories.php';
-	if ( ! class_exists( 'Bp_Customizable_Group_Categories' ) ) {
-		require CBOXOL_PLUGIN_DIR . 'lib/bp-customizable-group-categories/bp-customizable-group-categories.php';
-		$bpcgc_plugin = new Bp_Customizable_Group_Categories();
-		$bpcgc_plugin->run();
-	}
 
 	// @todo Better loading for these libraries.
 	require CBOXOL_PLUGIN_DIR . 'includes/portfolios.php';
@@ -61,7 +63,12 @@ function cboxol_init() {
 		require CBOXOL_PLUGIN_DIR . 'plugins/pressforward.php';
 	}
 
+	$ver = get_site_option( 'cboxol_ver' );
+	if ( ! empty( $ver ) ) {
+		require CBOXOL_PLUGIN_DIR . 'includes/network-toolbar.php';
+	}
+
 	// Must wait until WP is set up.
-	add_action( 'init', 'cboxol_maybe_install' );
+	add_action( 'bp_init', 'cboxol_maybe_install' );
 }
 add_action( 'plugins_loaded', 'cboxol_init' );

--- a/cbox-openlab-core.php
+++ b/cbox-openlab-core.php
@@ -69,6 +69,7 @@ function cboxol_init() {
 	}
 
 	// Must wait until WP is set up.
-	add_action( 'bp_init', 'cboxol_maybe_install' );
+	remove_action( 'after_switch_theme', '_wp_sidebars_changed' );
+	add_action( 'after_switch_theme', 'cboxol_maybe_install', 200 );
 }
 add_action( 'plugins_loaded', 'cboxol_init' );

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -179,6 +179,14 @@ function cboxol_maybe_install() {
 		return;
 	}
 
+	if ( ! bp_is_active( 'groups' ) ) {
+		return;
+	}
+
+	if ( ! function_exists( 'openlab_core_setup' ) ) {
+		return;
+	}
+
 	$ver = get_site_option( 'cboxol_ver' );
 
 	if ( ! $ver ) {


### PR DESCRIPTION
As previously discussed, this PR avoids fatal errors when activating `cbox-openlab-core` on its own,
if BuddyPress or the openlab-theme is not already active.

Apart from the `require` changes, the other main change is to `cboxol_maybe_install()`.  It now runs only when BuddyPress is active via the `bp_init` hook and I've altered the function to check for the existence of the `openlab-theme` since `cbox-openlab-core` and `openlab-theme` are intertwined.

I've found that this is the minimal amount of change required, but let me know what you think, @boonebgorges.

I've tested the CBOX installer with this change and it works okay.

I have one question and that is what the default look of CBOX-OL should look like out-of-the-box.

This is what I get:

![Screenshot of CBOX-OL after CBOX installation](https://user-images.githubusercontent.com/505921/39879889-965131e2-546b-11e8-9c3c-8bf00396d35a.png)

The right widget area, "Home Main", is blank because no courses have been created yet.  The course widget is properly added though:

![Screenshot of Appearance > Widgets page](https://user-images.githubusercontent.com/505921/39880045-0e4e95c2-546c-11e8-858a-865cc7d77943.png)

Lastly, for the "Home Sidebar" widget area, the CBOX-OL widgets get added correctly, but you also see the default WordPress widgets.  I'm not sure if that is supposed to be there or not.  I'm guessing it should because we might have to take into account existing widgets from previous installs, perhaps?