### PR TITLE
Install: Set time limit to unlimited

### DIFF
--- a/classes/Install.php
+++ b/classes/Install.php
@@ -16,6 +16,11 @@ class Install {
 	}
 
 	public function install() {
+		// If safe mode isn't on, then let's set the execution time to unlimited.
+		if ( ! ini_get( 'safe_mode' ) ) {
+			set_time_limit( 0 );
+		}
+
 		$this->install_default_member_types();
 		$this->install_default_group_types();
 		$this->install_default_group_categories();


### PR DESCRIPTION
Was testing a fresh install and encountered a timeout issue during OL installation.

The `install()` method was taking longer than the default PHP time limit and was unable to complete.  It was hanging during the group types installation step the longest:
https://github.com/cuny-academic-commons/cbox-openlab-core/blob/master/classes/Install.php#L20

The simplest way to fix this is to set the time limit during install to unlimited, but this relies on PHP's safe mode being off.

---

When the install does not complete, this cascades into other problems as the `cboxol_installing` option is left in the DB and the `cboxol_version` option is never saved.  This leads to the toolbar customizations file not being loaded:
https://github.com/cuny-academic-commons/cbox-openlab-core/blob/master/cbox-openlab-core.php#L68

Which causes the `openlab-theme` to fatal on the frontend:
https://github.com/cuny-academic-commons/openlab-theme/blob/master/functions.php#L321
https://github.com/cuny-academic-commons/openlab-theme/blob/master/lib/theme-hooks.php#L56

Do we want to do anything different for the loading of the toolbar?  I think the main reason why I put a conditional was due to the jarring nature of seeing the OL toolbar during the CBOX theme installation step, which occurs after the CBOX-OpenLab-Core plugin is activated.  If I'm being too sensitive about the UX experience here, then feel free to remove the version conditional check as noted above.

