### PR TITLE
Fix fatal error when deactivating the main CBOX plugin

### DIFF
--- a/includes/group-types.php
+++ b/includes/group-types.php
@@ -190,7 +190,7 @@ function cboxol_get_group_types( $args = array() ) {
 	);
 
 	$switched = false;
-	$main_site_id = cbox_get_main_site_id();
+	$main_site_id = function_exists( 'cbox_get_main_site_id' ) ? cbox_get_main_site_id() : (int) get_current_site()->blog_id;
 	if ( get_current_blog_id() !== $main_site_id ) {
 		switch_to_blog( $main_site_id );
 		$switched = true;

--- a/includes/member-types.php
+++ b/includes/member-types.php
@@ -101,7 +101,7 @@ function cboxol_get_member_types( $args = array() ) {
 	);
 
 	$switched = false;
-	$main_site_id = cbox_get_main_site_id();
+	$main_site_id = function_exists( 'cbox_get_main_site_id' ) ? cbox_get_main_site_id() : (int) get_current_site()->blog_id;
 	if ( get_current_blog_id() !== $main_site_id ) {
 		switch_to_blog( $main_site_id );
 		$switched = true;


### PR DESCRIPTION
Hi @boonebgorges,

Discovered a fatal error with the OpenLab package when deactivating the "Commons In A Box" plugin.

When the CBOX plugin is deactivated from the WP Plugins admin page, the `cbox-openlab-core` plugin still calls upon the CBOX function, `cbox_get_main_site_id()`, which is no longer available and causes the fatal error.

To address this, I decided to do a `function_exists()` check.  If our CBOX function isn't available, we fallback on the main site's blog ID.  Let me know what you think of this fix and whether it is suitable for the cbox-openlab-core plugin.