### PR TITLE
Adds utility function for fetching site type

### DIFF
--- a/includes/group-sites.php
+++ b/includes/group-sites.php
@@ -64,7 +64,7 @@ function cboxol_set_group_site_id( $group_id, $site_id ) {
  * Get site type based on the group type.
  *
  * @param int $site_id
- * @return string
+ * @return string $group_type
  */
 function cboxol_get_group_site_type( $site_id ) {
 	$group_id = cboxol_get_group_site_id( $site_id );
@@ -73,7 +73,12 @@ function cboxol_get_group_site_type( $site_id ) {
 		return '';
 	}
 
-	return openlab_get_group_type( $group_id );
+	$group_type = cboxol_get_group_group_type( $group_id );
+	if ( is_wp_error( $group_type ) ) {
+		return '';
+	}
+
+	return $group_type;
 }
 
 /**

--- a/includes/group-sites.php
+++ b/includes/group-sites.php
@@ -61,6 +61,22 @@ function cboxol_set_group_site_id( $group_id, $site_id ) {
 }
 
 /**
+ * Get site type based on the group type.
+ *
+ * @param int $site_id
+ * @return string
+ */
+function cboxol_get_group_site_type( $site_id ) {
+	$group_id = cboxol_get_group_site_id( $site_id );
+
+	if ( ! $group_id ) {
+		return '';
+	}
+
+	return openlab_get_group_type( $group_id );
+}
+
+/**
  * Use this function to get the URL of a group's site. It'll work whether the site is internal
  * or external
  *


### PR DESCRIPTION
This PR introduces `cboxol_get_group_site_type`.

@boonebgorges I'm using `openlab_get_group_type` instead of `cboxol_get_group_group_type`. Latter checks for BP core group type and return WP_Error if group doesn't have a type.
